### PR TITLE
It seems Xemu/Mega65 is able to "boot" now

### DIFF
--- a/common/cpu65c02.h
+++ b/common/cpu65c02.h
@@ -37,6 +37,9 @@ extern Uint16 cpu_sphi;	// NOTE: it must store the value shifted to the high byt
 extern void  cpu_write     ( Uint16 addr, Uint8 data );
 extern void  cpu_write_rmw ( Uint16 addr, Uint8 old_data, Uint8 new_data );
 extern Uint8 cpu_read      ( Uint16 addr );
+#ifdef MEGA65
+extern void  cpu_write_linear_opcode ( Uint8 data );
+#endif
 
 extern void cpu_reset ( void );
 extern int  cpu_step  ( void );

--- a/common/emutools.h
+++ b/common/emutools.h
@@ -38,6 +38,8 @@ extern void emu_drop_events ( void );
 	char _buf_for_win_msg_[4096]; \
 	snprintf(_buf_for_win_msg_, sizeof _buf_for_win_msg_, __VA_ARGS__); \
 	fprintf(stderr, str ": %s" NL, _buf_for_win_msg_); \
+	if (debug_fp)	\
+		fprintf(debug_fp, str ": %s" NL, _buf_for_win_msg_);	\
 	SDL_ShowSimpleMessageBox(sdlflag, sdl_window_title, _buf_for_win_msg_, sdl_win); \
 	clear_emu_events(); \
 	emu_drop_events(); \

--- a/targets/mega65/c65fdc.c
+++ b/targets/mega65/c65fdc.c
@@ -142,7 +142,7 @@ static void read_sector ( void )
 		status_b &= (255- 4); // no disk inserted ...
 		DEBUG("FDC: READ: no valid image file!" NL);
 		if (warn_disk) {
-			INFO_WINDOW("No disk image was given or can be loaded!\nStart emulator with the disk image as parameter!");
+			INFO_WINDOW("No disk image was given or can be loaded!\nStart emulator with the disk image as parameter!\nMEGA65 FDC emulation is not ready yet, this is a C65 emu feature :(");
 			warn_disk = 0;
 		}
 	}

--- a/targets/mega65/dmagic.c
+++ b/targets/mega65/dmagic.c
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 */
 
 
-static Uint8 dma_registers[16];		// The four DMA registers (with last values written by the CPU)
+Uint8 dma_registers[16];		// The four DMA registers (with last values written by the CPU)
 static int   source_step;		// [-1, 0, 1] step value for source (0 = hold, constant address)
 static int   target_step;		// [-1, 0, 1] step value for target (0 = hold, constant address)
 static int   source_addr;		// DMA source address (the low byte is also used by COPY command as the "filler byte")

--- a/targets/mega65/dmagic.h
+++ b/targets/mega65/dmagic.h
@@ -19,6 +19,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define __XEMU_DMAGIC_MEGA65_H_INCLUDED
 
 extern Uint8 dma_status;
+extern Uint8 dma_registers[16];
 
 extern void  dma_write_reg ( int addr, Uint8 data );
 extern Uint8 dma_read_reg  ( int reg );

--- a/targets/mega65/hypervisor.c
+++ b/targets/mega65/hypervisor.c
@@ -205,6 +205,16 @@ void hypervisor_serial_monitor_push_char ( Uint8 chr )
 
 
 
+void hypervisor_debug_invalidate ( void )
+{
+	if (resolver_ok) {
+		resolver_ok = 0;
+		INFO_WINDOW("Hypervisor debug feature is asked to be disabled (ie: upgraded kickstart?)");
+	}
+}
+
+
+
 void hypervisor_debug ( void )
 {
 	if (!in_hypervisor)
@@ -222,13 +232,12 @@ void hypervisor_debug ( void )
 	if (!resolver_ok) {
 		return;	// no debug info loaded from kickstart.list ...
 	}
-	if (unlikely(!debug_lines[cpu_pc - 0x8000][0])) {
+	if (unlikely(!debug_lines[cpu_pc - 0x8000][0][0])) {
 		DEBUG("HYPERVISOR-DEBUG: execution address not found in list file (out-of-bound code?), PC = $%04X" NL, cpu_pc);
 		FATAL("Hypervisor fatal error: execution address not found in list file (out-of-bound code?), PC = $%04X", cpu_pc);
 		return;
 	}
-	// WARNING: as it turned out, using snprintf() is EXTREMLY slow to call at the frequency of the emulated CPU clock (~3.5MHz)
-	// even on a "modern" PC. TODO: this must be rewritten to use custom "rendering" of debug information, instead of stdio stuffs!
+	// WARNING: as it turned out, using stdio I/O to log every opcodes even "only" at ~3.5MHz rate makes emulation _VERY_ slow ...
 #ifdef HYPERVISOR_DEBUG
 	if (debug_fp)
 		fprintf(

--- a/targets/mega65/hypervisor.c
+++ b/targets/mega65/hypervisor.c
@@ -242,7 +242,7 @@ void hypervisor_debug ( void )
 	if (debug_fp)
 		fprintf(
 			debug_fp,
-			"HYPERVISOR-DEBUG: %-32s PC=%04X SP=%04X B=%02X A=%02X X=%02X Y=%02X Z=%02X P=%c%c%c%c%c%c%c%c @ %s" NL,
+			"HYPERVISOR-DEBUG: %-32s PC=%04X SP=%04X B=%02X A=%02X X=%02X Y=%02X Z=%02X P=%c%c%c%c%c%c%c%c IO=%d @ %s" NL,
 			debug_lines[cpu_pc - 0x8000][0],
 			cpu_pc, cpu_sphi | cpu_sp, cpu_bphi >> 8, cpu_a, cpu_x, cpu_y, cpu_z,
 			cpu_pfn ? 'N' : 'n',
@@ -253,6 +253,7 @@ void hypervisor_debug ( void )
 			cpu_pfi ? 'I' : 'i',
 			cpu_pfz ? 'Z' : 'z',
 			cpu_pfc ? 'C' : 'c',
+			vic_iomode,
 			debug_lines[cpu_pc - 0x8000][1]
 		);
 #endif

--- a/targets/mega65/hypervisor.c
+++ b/targets/mega65/hypervisor.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #include "hypervisor.h"
 #include "cpu65c02.h"
 #include "vic3.h"
+#include "dmagic.h"
 
 #define INFO_MAX_SIZE	32
 
@@ -182,6 +183,9 @@ void hypervisor_leave ( void )
 	// Now leaving hypervisor mode ...
 	in_hypervisor = 0;
 	apply_memory_config();
+	// FIXME: ugly hack: C65 ROM goes nuts if "MB" part of DMA source/target is not reset here!
+	dma_registers[5] = 0;
+        dma_registers[6] = 0;
 	DEBUG("MEGA65: leaving hypervisor mode, (user) PC=$%04X" NL, cpu_pc);
 }
 

--- a/targets/mega65/hypervisor.h
+++ b/targets/mega65/hypervisor.h
@@ -24,5 +24,6 @@ extern void hypervisor_debug ( void );
 extern void hypervisor_enter ( int trapno );
 extern void hypervisor_leave ( void );
 extern void hypervisor_serial_monitor_push_char ( Uint8 chr );
+extern void hypervisor_debug_invalidate ( void );
 
 #endif

--- a/targets/mega65/mega65.c
+++ b/targets/mega65/mega65.c
@@ -414,7 +414,7 @@ Uint8 io_read ( int addr )
 				case 0xD67E:				// upgraded hypervisor signal
 					if (kicked_hypervisor == 0x80)	// 0x80 means for Xemu (not for a real M65!): ask the user!
 						kicked_hypervisor = QUESTION_WINDOW(
-							"Not upgraded yet, it can do it|Already upgraded",
+							"Not upgraded yet, it can do it|Already upgraded, I test kicked state",
 							"Kickstart asks hypervisor upgrade state. What do you want Xemu to answer?\n"
 							"(don't worry, it won't be asked again without RESET)"
 						) ? 0xFF : 0;
@@ -538,6 +538,7 @@ void io_write ( int addr, Uint8 data )
 				case 0xD67E:	// it seems any write (?) here marks the byte as non-zero?! FIXME TODO
 					kicked_hypervisor = 0xFF;
 					fprintf(stderr, "Writing already-kicked register $%04X!" NL, addr);
+					hypervisor_debug_invalidate();
 					break;
 				case 0xD67F:	// hypervisor enter/leave trap
 					if (in_hypervisor)

--- a/targets/mega65/mega65.c
+++ b/targets/mega65/mega65.c
@@ -536,7 +536,10 @@ void io_write ( int addr, Uint8 data )
 					hypervisor_serial_monitor_push_char(data);
 					break;
 				case 0xD67D:
-					rom_protect = data & 4;
+					if ((data & 4) != rom_protect) {
+						fprintf(stderr, "MEGA65: ROM protection has been turned %s." NL, data & 4 ? "ON" : "OFF");
+						rom_protect = data & 4;
+					}
 					break;
 				case 0xD67E:	// it seems any write (?) here marks the byte as non-zero?! FIXME TODO
 					kicked_hypervisor = 0xFF;

--- a/targets/mega65/mega65.h
+++ b/targets/mega65/mega65.h
@@ -38,8 +38,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #define HYPERVISOR_DEBUG
 
 // State of FPGA board switches (bits 0 - 15), set switch 12 (hypervisor serial output)
-// 12 is useful, but it also slows things down
+// 12 is useful, but it also slows things emulation down maybe (I am not sure, but
+// kickstat may wait after every "Checkpoint" messages ...)
 #define FPGA_SWITCHES		1 << 12
+//#define FPGA_SWITCHES		0
 
 // You may want to disable audio emulation since it can disturb non-real-time emulation
 #define AUDIO_EMULATION

--- a/targets/mega65/mega65.h
+++ b/targets/mega65/mega65.h
@@ -35,7 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 // If you define this, you will got *VERY HUGE* number of messages into the debug log
 // It slows down the emulator *A LOT* as well!
 // With FPGA switch 12 too, it created 20Gbytes(!) log file and it even not booted yet :)
-#define HYPERVISOR_DEBUG
+// #define HYPERVISOR_DEBUG
 
 // State of FPGA board switches (bits 0 - 15), set switch 12 (hypervisor serial output)
 // 12 is useful, but it also slows things emulation down maybe (I am not sure, but

--- a/targets/mega65/sdcard.c
+++ b/targets/mega65/sdcard.c
@@ -68,7 +68,7 @@ int sdcard_init ( const char *fn )
 				return sdfd;
 			}
 			DEBUG("SDCARD: detected size in Mbytes: %d" NL, (int)(sd_card_size >> 20));
-			if (sd_card_size & 511) {
+			if (sd_card_size & (off_t)511) {
 				ERROR_WINDOW("SD-card image size is not multiple of 512 bytes!!");
 				close(sdfd);
 				sdfd = -1;
@@ -111,11 +111,11 @@ static int read_sector ( void )
 	int ret;
 	if (sdfd < 0)
 		return -1;
-	offset = sd_sector_bytes[0] | (sd_sector_bytes[1] << 8) | (sd_sector_bytes[2] << 16) | (sd_sector_bytes[3] << 24);
+	offset = (off_t)sd_sector_bytes[0] | ((off_t)sd_sector_bytes[1] << 8) | ((off_t)sd_sector_bytes[2] << 16) | ((off_t)sd_sector_bytes[3] << 24);
 	DEBUG("SDCARD: reading position %ld PC=$%04X" NL, (long)offset, cpu_pc);
 	if (offset < 0 || offset >= sd_card_size) {
 		DEBUG("SDCARD: invalid position value failure ..." NL);
-		FATAL("SDCARD: invalid position value failure!! %ld (limit = %ld)", (long)offset, (long)sd_card_size);
+		FATAL("SDCARD: invalid position value failure!! %lld (limit = %lld)", (long long int)offset, (long long int)sd_card_size);
 		return -1;
 	}
 	if (lseek(sdfd, offset, SEEK_SET) != offset) {


### PR DESCRIPTION
Tested with/without upgrading the hypervisor. However, no disk emulation is yet at FDC level (just what remained from C65 emu, but that used discrete D81 files). SYS49152 from C64 mode starts the disk chooser, but it reports no hypervisor responding. Naturally and literally tons of works left ...